### PR TITLE
Fix GH links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a question
-    url: https://github.com/solution-forest/filament-panphp/discussions/new?category=q-a
+    url: https://github.com/solutionforest/filament-panphp/discussions/new?category=q-a
     about: Ask the community for help
   - name: Request a feature
-    url: https://github.com/solution-forest/filament-panphp/discussions/new?category=ideas
+    url: https://github.com/solutionforest/filament-panphp/discussions/new?category=ideas
     about: Share ideas for new features
   - name: Report a security issue
-    url: https://github.com/solution-forest/filament-panphp/security/policy
+    url: https://github.com/solutionforest/filament-panphp/security/policy
     about: Learn how to notify us for sensitive bugs

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Filament UI for Pan Analytics
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/solution-forest/filament-panphp.svg?style=flat-square)](https://packagist.org/packages/solution-forest/filament-panphp)
-[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/solution-forest/filament-panphp/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/solution-forest/filament-panphp/actions?query=workflow%3Arun-tests+branch%3Amain)
-[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/solution-forest/filament-panphp/fix-php-code-styling.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/solution-forest/filament-panphp/actions?query=workflow%3A"Fix+PHP+code+styling"+branch%3Amain)
+[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/solutionforest/filament-panphp/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/solutionforest/filament-panphp/actions?query=workflow%3Arun-tests+branch%3Amain)
+[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/solutionforest/filament-panphp/fix-php-code-style-issues.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/solutionforest/filament-panphp/actions?query=workflow%3A"Fix+PHP+code+styling"+branch%3Amain)
 [![Total Downloads](https://img.shields.io/packagist/dt/solution-forest/filament-panphp.svg?style=flat-square)](https://packagist.org/packages/solution-forest/filament-panphp)
 
 

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
         "laravel",
         "filament-panphp"
     ],
-    "homepage": "https://github.com/solution-forest/filament-panphp",
+    "homepage": "https://github.com/solutionforest/filament-panphp",
     "support": {
-        "issues": "https://github.com/solution-forest/filament-panphp/issues",
-        "source": "https://github.com/solution-forest/filament-panphp"
+        "issues": "https://github.com/solutionforest/filament-panphp/issues",
+        "source": "https://github.com/solutionforest/filament-panphp"
     },
     "license": "MIT",
     "authors": [{

--- a/src/FilamentPanphpServiceProvider.php
+++ b/src/FilamentPanphpServiceProvider.php
@@ -36,7 +36,7 @@ class FilamentPanphpServiceProvider extends PackageServiceProvider
                     ->publishConfigFile()
                     // ->publishMigrations()
                     // ->askToRunMigrations()
-                    ->askToStarRepoOnGitHub('solution-forest/filament-panphp');
+                    ->askToStarRepoOnGitHub('solutionforest/filament-panphp');
             });
 
         $configFileName = $package->shortName();


### PR DESCRIPTION
I fixed GitHub links that pointed to `solution-forest` instead of `solution forest`. Badges now work correctly, and "ask to star repo" now points to the correct repo.